### PR TITLE
Clean up Netty TCP implementation.

### DIFF
--- a/core/.gitignore
+++ b/core/.gitignore
@@ -1,2 +1,0 @@
-test-output/
-/target

--- a/core/src/main/java/net/kuujo/copycat/resource/internal/PassiveState.java
+++ b/core/src/main/java/net/kuujo/copycat/resource/internal/PassiveState.java
@@ -151,7 +151,7 @@ public class PassiveState extends AbstractState {
             }
           } else {
             // If the request failed then record the member as INACTIVE.
-            LOGGER.debug("{} - Sync to {} failed", context.getLocalMember(), member);
+            LOGGER.warn("{} - Sync to {} failed: {}", context.getLocalMember(), member, error.getMessage());
             future.completeExceptionally(error);
           }
         }

--- a/test-tools/.gitignore
+++ b/test-tools/.gitignore
@@ -1,2 +1,0 @@
-test-output/
-/target

--- a/test-tools/src/main/java/net/kuujo/copycat/test/ProtocolTest.java
+++ b/test-tools/src/main/java/net/kuujo/copycat/test/ProtocolTest.java
@@ -192,6 +192,7 @@ public abstract class ProtocolTest extends ConcurrentTestCase {
     client.connect().thenRunAsync(this::resume);
     await(5000);
 
+    expectResume();
     client.write(ByteBuffer.wrap("Hello world!".getBytes())).thenAcceptAsync(buffer -> {
       byte[] bytes = new byte[buffer.remaining()];
       buffer.get(bytes);
@@ -200,6 +201,7 @@ public abstract class ProtocolTest extends ConcurrentTestCase {
     });
     await(5000);
 
+    expectResume();
     client.write(ByteBuffer.wrap("Hello world!".getBytes())).thenAcceptAsync(buffer -> {
       byte[] bytes = new byte[buffer.remaining()];
       buffer.get(bytes);
@@ -208,6 +210,7 @@ public abstract class ProtocolTest extends ConcurrentTestCase {
     });
     await(5000);
 
+    expectResume();
     client.write(ByteBuffer.wrap("Hello world!".getBytes())).thenAcceptAsync(buffer -> {
       byte[] bytes = new byte[buffer.remaining()];
       buffer.get(bytes);
@@ -215,6 +218,14 @@ public abstract class ProtocolTest extends ConcurrentTestCase {
       resume();
     });
     await(5000);
+
+    expectResume();
+    client.close().thenRunAsync(this::resume);
+    await(2500);
+
+    expectResume();
+    server.close().thenRunAsync(this::resume);
+    await(2500);
   }
 
 }

--- a/test-tools/src/main/java/net/kuujo/copycat/test/TestCluster.java
+++ b/test-tools/src/main/java/net/kuujo/copycat/test/TestCluster.java
@@ -29,6 +29,7 @@ import java.util.function.Function;
  * @author <a href="http://github.com/kuujo">Jordan Halterman</a>
  */
 public class TestCluster<T extends Resource<T>> {
+  private static int id;
   private final List<T> activeResources;
   private final List<T> passiveResources;
 
@@ -102,10 +103,10 @@ public class TestCluster<T extends Resource<T>> {
 
       List<T> activeResources = new ArrayList<>(activeMembers);
 
-      int i = 0;
       Set<String> members = new HashSet<>(activeMembers);
-      while (i <= activeMembers) {
-        String uri = uriFactory.apply(++i);
+      int activeCount = activeMembers + id;
+      while (id <= activeCount) {
+        String uri = uriFactory.apply(id++);
         members.add(uri);
       }
 
@@ -115,8 +116,9 @@ public class TestCluster<T extends Resource<T>> {
       }
 
       List<T> passiveResources = new ArrayList<>(passiveMembers);
-      while (i <= passiveMembers + activeMembers) {
-        String member = uriFactory.apply(++i);
+      int passiveCount = passiveMembers + id;
+      while (id <= passiveCount) {
+        String member = uriFactory.apply(id++);
         ClusterConfig cluster = clusterFactory.apply(members).withLocalMember(member);
         passiveResources.add(resourceFactory.apply(cluster));
       }


### PR DESCRIPTION
Cherry-pick of e56c7f1708fe3cfede789899d4ee9eccd7189758 (upstream)

Conflicts:
    core/src/main/java/net/kuujo/copycat/resource/internal/PassiveState.java
    netty/src/main/java/net/kuujo/copycat/netty/NettyTcpProtocolClient.java
    netty/src/main/java/net/kuujo/copycat/netty/NettyTcpProtocolServer.java
    test-tools/src/main/java/net/kuujo/copycat/test/ProtocolTest.java
    test-tools/src/main/java/net/kuujo/copycat/test/TestCluster.java
